### PR TITLE
Adjust function folding start point

### DIFF
--- a/src/lang/psi/impl/statements/LuaFunctionDefinitionStatementImpl.java
+++ b/src/lang/psi/impl/statements/LuaFunctionDefinitionStatementImpl.java
@@ -187,7 +187,7 @@ public class LuaFunctionDefinitionStatementImpl extends LuaStatementElementImpl 
     public TextRange getRangeEnclosingBlock() {
         final PsiElement rparen = findChildByType(LuaElementTypes.RPAREN);
         if (rparen == null) return getTextRange();
-        return TextRange.create(rparen.getTextOffset(), getTextRange().getEndOffset());
+        return TextRange.create(rparen.getTextRange().getEndOffset(), getTextRange().getEndOffset());
     }
 
 

--- a/src/lang/psi/impl/statements/LuaFunctionDefinitionStatementImpl.java
+++ b/src/lang/psi/impl/statements/LuaFunctionDefinitionStatementImpl.java
@@ -155,7 +155,7 @@ public class LuaFunctionDefinitionStatementImpl extends LuaStatementElementImpl 
     }
 
     @Override
-    public PsiElement setName(String s) {
+    public PsiElement setName(@NotNull String s) {
         return getIdentifier().setName(s);
     }
 


### PR DESCRIPTION
When folding functions, the folded range currently includes the closing (right) parenthesis of the parameter list.  This patch moves the folding start to the character after the closing parenthesis.

![screenshot from 2016-01-31 21-38-03](https://cloud.githubusercontent.com/assets/16406328/12707475/ef0540cc-c862-11e5-92d6-b56027ea0d04.png)
